### PR TITLE
fix(media): Fix image upload by using the correct parameter name

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -695,7 +695,7 @@ impl Mastodon {
         use reqwest::multipart::Form;
 
         let mut form_data = Form::new()
-            .file(stringify!(media_builder.file), media_builder.file.as_ref())?;
+            .file("file", media_builder.file.as_ref())?;
 
         if let Some(description) = media_builder.description {
             form_data = form_data.text("description", description);


### PR DESCRIPTION
Follow up to #46, fixes #47 