### PR TITLE
Add min_id and exclude_reblogs parameters to StatusesRequest

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -352,6 +352,7 @@ pub struct StatusesRequest<'a> {
     since_id: Option<Cow<'a, str>>,
     min_id: Option<Cow<'a, str>>,
     limit: Option<usize>,
+    exclude_reblogs: bool,
 }
 
 impl<'a> StatusesRequest<'a> {
@@ -394,6 +395,11 @@ impl<'a> StatusesRequest<'a> {
         self
     }
 
+    pub fn exclude_reblogs(mut self) -> Self {
+        self.exclude_reblogs = true;
+        self
+    }
+
     pub fn to_querystring(&self) -> String {
         let mut opts = vec![];
 
@@ -423,6 +429,10 @@ impl<'a> StatusesRequest<'a> {
 
         if let Some(limit) = self.limit {
             opts.push(format!("limit={}", limit));
+        }
+
+        if self.exclude_reblogs {
+            opts.push("exclude_reblogs=1".into());
         }
 
         if opts.is_empty() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -350,6 +350,7 @@ pub struct StatusesRequest<'a> {
     pinned: bool,
     max_id: Option<Cow<'a, str>>,
     since_id: Option<Cow<'a, str>>,
+    min_id: Option<Cow<'a, str>>,
     limit: Option<usize>,
 }
 
@@ -383,6 +384,11 @@ impl<'a> StatusesRequest<'a> {
         self
     }
 
+    pub fn min_id<S: Into<Cow<'a, str>>>(mut self, min_id: S) -> Self {
+        self.min_id = Some(min_id.into());
+        self
+    }
+
     pub fn limit(mut self, limit: usize) -> Self {
         self.limit = Some(limit);
         self
@@ -409,6 +415,10 @@ impl<'a> StatusesRequest<'a> {
 
         if let Some(ref since_id) = self.since_id {
             opts.push(format!("since_id={}", since_id));
+        }
+
+        if let Some(ref min_id) = self.min_id {
+            opts.push(format!("min_id={}", min_id));
         }
 
         if let Some(limit) = self.limit {


### PR DESCRIPTION
I've ordered them in the code according to how they're ordered in [the REST API documentation](https://docs.joinmastodon.org/api/rest/accounts/#get-api-v1-accounts-id-statuses).